### PR TITLE
Update readme

### DIFF
--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -2,12 +2,7 @@
 # Overview
 RMV wait times data is hosted and managed by MassDOT (see feed url below). This data is used by the Mayflower design system (Mayflower Assets), and is fronted by an AWS API Gateway `rmvwaittime (9p83os0fkf)`.
 
-In order to change the MassDOT server url, if/when needed, Go to _AWS > APIs > rmvwaittime (9p83os0fkf) > Resources>/waittime (a5hsyy) > GET_
-
-
-## Amazon API Gateway
-APIs > rmvwaittime (9p83os0fkf) > Resources>/waittime (a5hsyy) > GET > Endpoint URL
-
+In order to change the MassDOT server url, if/when needed, Go to:  AWS > APIs > rmvwaittime (9p83os0fkf) > Resources>/waittime (a5hsyy) > GET waittime > Integration Request
 
 ## Feed URL:
 ### Old feed url:

--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -1,13 +1,17 @@
 
 # Overview
-RMV wait times data is hosted and managed by MassDOT (see feed url below). This data is used by the Mayflower design system (Mayflower Assets), and is fronted by an AWS API Gateway `rmvwaittime (9p83os0fkf)`.
+RMV wait time data is hosted and managed by MassDOT (see feed url below). This data is used in an iFrame field on the location content type in Mass.gov. Each RMV location page specifies the particular municipality to pull the wait time for, e.g.: "https://massgov.github.io/rmvwaittime/?town=Boston."
 
-In order to change the MassDOT server url, if/when needed, Go to:  AWS > APIs > rmvwaittime (9p83os0fkf) > Resources>/waittime (a5hsyy) > GET waittime > Integration Request
+The widget is hosted at massgov.github.io/rmvwaittime, which pulls data from the AWS API Gateway `rmvwaittime (9p83os0fkf)`. That, in turn, pulls data from a feed at MassDOT:
 
 ## Feed URL:
+https://dotfeeds.state.ma.us/api/RMVBranchWaitTime/Index
+
+In order to change the MassDOT server url, if/when needed, Go to:  AWS > APIs > rmvwaittime (9p83os0fkf) > Resources>/waittime (a5hsyy) > GET waittime > Integration Request.
+
 ### Old feed url:
+This URL was in place until 6/14/2019:
 https://www.massdot.state.ma.us/feeds/qmaticxml/qmaticXML.aspx 
 
-### New feed url:
-https://dotfeeds.state.ma.us/api/RMVBranchWaitTime/Index
+
 

--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -1,0 +1,21 @@
+
+# Overview
+RMV wait times data is hosted and managed by MassDOT (see feed url below). This data is used by the Mayflower design system (Mayflower Assets), and is fronted by an AWS API Gateway `rmvwaittime (9p83os0fkf)`.
+
+In order to change the MassDOT server url, if/when needed, Go to _AWS > APIs > rmvwaittime (9p83os0fkf) > Resources>/waittime (a5hsyy) > GET_
+
+
+## Amazon API Gateway
+APIs > rmvwaittime (9p83os0fkf) > Resources>/waittime (a5hsyy) > GET > Endpoint URL
+
+```
+var rmvWaitTimeURL = 'https://9p83os0fkf.execute-api.us-east-1.amazonaws.com/v1/waittime';
+```
+
+## Feed URL:
+### Old feed url:
+https://www.massdot.state.ma.us/feeds/qmaticxml/qmaticXML.aspx 
+
+### New feed url:
+https://dotfeeds.state.ma.us/api/RMVBranchWaitTime/Index
+

--- a/docs/api-gateway.md
+++ b/docs/api-gateway.md
@@ -8,9 +8,6 @@ In order to change the MassDOT server url, if/when needed, Go to _AWS > APIs > r
 ## Amazon API Gateway
 APIs > rmvwaittime (9p83os0fkf) > Resources>/waittime (a5hsyy) > GET > Endpoint URL
 
-```
-var rmvWaitTimeURL = 'https://9p83os0fkf.execute-api.us-east-1.amazonaws.com/v1/waittime';
-```
 
 ## Feed URL:
 ### Old feed url:

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ and presents them using a component which uses Mayflower Assets.
 
 ## Dependencies
 - Static assets copied from [Mayflower v3.1.0](http://mayflower.digital.mass.gov/)
-- RMV wait time data feed: https://www.massdot.state.ma.us/feeds/qmaticxml/qmaticXML.aspx
+- RMV wait time data feed: https://dotfeeds.state.ma.us/api/RMVBranchWaitTime/Index
 - CORS enabled API proxy using AWS (_since data source is not cors enabled_): http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-cors.html 
 
 ## Working with the App


### PR DESCRIPTION
Update to use the new data feed url from MassDOT

**Jira:**
https://jira.mass.gov/browse/DP-14198

**Test:**
After saving the new URL on AWS via the console in the API Gateway in question `rmvwaittime (9p83os0fkf)`, test this page to make sure, it is returning a wait time:
https://www.mass.gov/locations/boston-haymarket-rmv-service-center